### PR TITLE
Add missing field

### DIFF
--- a/.changeset/few-pillows-share.md
+++ b/.changeset/few-pillows-share.md
@@ -1,0 +1,5 @@
+---
+'@bizniche/react': patch
+---
+
+add missing field to query for single post

--- a/lib/hooks/useGetPostQuery.ts
+++ b/lib/hooks/useGetPostQuery.ts
@@ -15,6 +15,7 @@ const GET_POST_QUERY = gql`
       title
       slug
       description
+      content
       author {
         id
         email


### PR DESCRIPTION
- adds missing field to `useGetPostQuery` hook